### PR TITLE
feat：添加Edge启动时关闭分组数据配置

### DIFF
--- a/popup.html
+++ b/popup.html
@@ -149,6 +149,13 @@
 			</label>
 			<span class="switch-label">扩展程序别名</span>
 		</div>
+		<div class="switch">
+			<label class="switch">
+			  <input type="checkbox" id="clearGroupedTabs" />
+			  <span class="slider"></span>
+			</label>
+			<span class="switch-label">启动时关闭分组(Edge)</span>
+		  </div>
 		<script src="popup.js"></script>
 	</body>
 </html>

--- a/popup.js
+++ b/popup.js
@@ -82,4 +82,20 @@ document.addEventListener("DOMContentLoaded", function () {
   });
 });
 
+document.addEventListener("DOMContentLoaded", function () {
+  const toggle = document.getElementById("clearGroupedTabs");
+
+  // 从 chrome.storage.local 中读取开关状态
+  chrome.storage.local.get(["clearGroupedTabs"], function (result) {
+    if (result.clearGroupedTabs !== undefined) {
+      toggle.checked = result.clearGroupedTabs; // 根据存储的值设置 toggle 的初始状态
+    }
+  });
+
+  // 当 toggle 开关状态改变时，将新状态写入 chrome.storage.local
+  toggle.addEventListener("change", function () {
+    const isEnabled = toggle.checked; // 获取当前开关状态
+    chrome.storage.local.set({ clearGroupedTabs: isEnabled }, function () {});
+  });
+});
 


### PR DESCRIPTION
自动分组后，Edge默认为固定选项卡组，关闭浏览器后，重新打开浏览器，上一次分组的数据还在，期望能添加一个重新打开浏览器，关闭上一次分组数据的标签页的功能 